### PR TITLE
Fixed double underlining for links.

### DIFF
--- a/anno/anno/static/anno.css
+++ b/anno/anno/static/anno.css
@@ -1,16 +1,3 @@
-a:link,
-a:visited,
-a:active {
-    border-bottom: 1px solid rgba(0, 0, 0, 0.5);
-    color: rgba(0, 0, 0, 0.8);
-    text-decoration: none;
-}
-
-a:hover {
-    color: black;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
-}
-
 body {
     margin: 0;
     padding: 0;
@@ -84,6 +71,39 @@ table {
     border-collapse: collapse;
 }
 
+#index-page a:link,
+#index-page a:visited,
+#index-page a:active,
+.nav-wrapper a:link,
+.nav-wrapper a:visited,
+.nav-wrapper a:active {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+    color: rgba(0, 0, 0, 0.8);
+    text-decoration: none;
+}
+
+#index-page a:hover,
+.nav-wrapper a:hover {
+    color: black;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+    text-decoration: none;
+}
+
+#index-page a.label:link,
+#index-page a.label:visited,
+#index-page a.label:active {
+    background-color: #005f83;
+    color: white;
+    border-bottom: none;
+    font-size: 13px;
+    padding: 2px 5px;
+}
+
+#index-page a.label:hover {
+    opacity: 0.7;
+    border-bottom: none;
+}
+
 #index-page table {
     margin-bottom: 100px;
 }
@@ -107,21 +127,6 @@ table {
 #note-page h1 {
     margin-top: 40px;
     line-height: 1em;
-}
-
-a.label:link,
-a.label:visited,
-a.label:active {
-    background-color: #005f83;
-    color: white;
-    border-bottom: none;
-    font-size: 13px;
-    padding: 2px 5px;
-}
-
-a.label:hover {
-    opacity: 0.7;
-    border-bottom: none;
 }
 
 #index-page .title-wrapper h1 {
@@ -222,4 +227,20 @@ figure {
 figure figcaption {
     font-size: 13px;
     text-align: left;
+}
+
+/* Markdown overwrites.
+ */
+.markdown-body a:link,
+.markdown-body a:visited,
+.markdown-body a:active {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+    color: rgba(0, 0, 0, 0.8);
+    text-decoration: none;
+}
+
+.markdown-body a:hover {
+    color: black;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+    text-decoration: none;
 }


### PR DESCRIPTION
`markdown.css` was not properly overwritten, causing both `markdown.css` and `anno.css` to underline the links, one with a border and the other with a text decorator. Gave `anno.css` precedence.