### PR TITLE
Check for open port before starting app

### DIFF
--- a/anno/annoapp.py
+++ b/anno/annoapp.py
@@ -5,6 +5,7 @@ A Flask-based Anno notebook server.
 from   anno.anno.app import app
 from   anno.anno.config import generate_config
 import argparse
+import socket
 import webbrowser
 
 
@@ -29,8 +30,13 @@ def main():
         msg   = f'Writing default config to: {fpath}'
         print(msg)
     else:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            result = sock.connect_ex(('127.0.0.1', args.port))
+            if result == 0:
+                raise OSError(f'Port {args.port} already in use.')
         if not args.nopen:
             webbrowser.open_new_tab(f'http://localhost:{args.port}/')
+
         app.run(debug=True,
                 host='0.0.0.0',
                 port=args.port,


### PR DESCRIPTION
This gives a more sensible user experience. Otherwise, if Anno is already open, the duplicate instance will crash but the new browser tab will still open to the existing instance, giving the temporary illusion of success.

Closes #22.