### PR TITLE
Remove Pandoc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 There are many note-taking apps. How is Anno different? Anno is a local, browser-based user interface on top of [Markdown](https://daringfireball.net/projects/markdown/) files in a given directory. It makes writing, organizing, and searching through those files easy. That's it. There are many benefits to this approach:
 
-- **Own your data.** Writing things down is an investment in your future. Rather than have your notes siloed by a company in a possibly proprietary text format, your data lives in plaintext files on your machine. If you use Anno for a while and then stop, no worries. Your data, Markdown files, is human-readable, easily portable to other tools, and programmatically convertable to other formats (see [Pandoc](https://pandoc.org/)).
+- **Own your data.** Writing things down is an investment in your future. Rather than have your notes siloed by a company in a possibly proprietary text format, your data lives in plaintext files on your machine. If you use Anno for a while and then stop, no worries. Your data, Markdown files, is human-readable, easily portable to other tools, and programmatically convertable to other formats (e.g. see [Pandoc](https://pandoc.org/)).
 
 - **Organize notes naturally.** Most note-taking apps create a new organizational system for your notes that is distinct from your filesystem. This forces you to store your notes separately from related files. Anno only works with `.anno.md` files in the current working directory, allowing you to organize your notes using your filesystem. Furthermore, all files with `labels` in the [YAML](https://yaml.org/)-style front matter can be viewed in their respective collections, making intra-directory organization easy without touching your underlying directory structure.
 
@@ -39,8 +39,6 @@ Anno is available as a [PyPI package](https://pypi.org/project/anno/). To instal
 pip install anno
 ```
 
-You must also install [Pandoc](https://pandoc.org/). To use the PDF converter, you need the `pdflatex` command, which ships with most TeX distributions.
-
 ### From source
 
 You can also install the current development version by building and installing:
@@ -51,6 +49,10 @@ cd anno
 python setup.py sdist
 pip install dist/anno-<VERSION>.tar.gz
 ```
+
+### LaTeX
+
+To use the PDF converter, you need [Pandoc](https://pandoc.org/) and the `pdflatex` command.
 
 ## Usage
 

--- a/anno/anno/app.py
+++ b/anno/anno/app.py
@@ -226,7 +226,13 @@ def image(img_name):
 def pdf(note_url):
     note_uid = unquote_plus(note_url)
     note = get_note(note_uid)
-    make_pdf(note)
+
+    try:
+        make_pdf(note)
+    except OSError:
+        flash('Failed to convert to PDF. Is Pandoc installed?')
+        return redirect(url_for('render', note_url=note_url))
+
     with open(note.pdf_fname, mode='rb') as f:
         response = make_response(f.read())
         response.headers['Content-Type'] = 'application/pdf'

--- a/anno/anno/render.py
+++ b/anno/anno/render.py
@@ -4,20 +4,28 @@ Functions for rendering Markdown and LaTeX as HTML.
 
 from   anno.anno.config import c
 import datetime
-import pypandoc
+import markdown2
 import re
 
 
 # -----------------------------------------------------------------------------
 
 def render_markdown(value):
-    extra_args = ['--katex']
-    output = pypandoc.convert_text(value, to='html5', format='md',
-                                   extra_args=extra_args)
+    import pypandoc
+
+    try:
+        extra_args = ['--katex']
+        output = pypandoc.convert_text(value, to='html5', format='md',
+                                       extra_args=extra_args)
+    except OSError:
+        output = markdown2.markdown(value, extras=['metadata', 'footnotes'])
+
     return output
 
 
 def make_pdf(note):
+    import pypandoc
+
     extra_args = ['-V', 'geometry:margin=1in', '--pdf-engine', 'pdflatex',
                   '-V', 'colorlinks', '-V', 'urlcolor=NavyBlue']
 
@@ -25,9 +33,9 @@ def make_pdf(note):
     #   [my caption](/image/foo.png)
     # with
     #   [my caption](/_images/foo.png)
-    # because I can't figure out how to tell Pandoc where the image files live.
+    # because I can't figure out how to tell Pandoc where the image files
+    #   live.
     text = re.sub(r'(\(/image/)', '(_images/', note.text)
-
     pypandoc.convert_text(text, to='pdf', format='md',
                           extra_args=extra_args,
                           outputfile=note.pdf_fname)

--- a/anno/anno/render.py
+++ b/anno/anno/render.py
@@ -5,13 +5,13 @@ Functions for rendering Markdown and LaTeX as HTML.
 from   anno.anno.config import c
 import datetime
 import markdown2
+import pypandoc
 import re
 
 
 # -----------------------------------------------------------------------------
 
 def render_markdown(value):
-    import pypandoc
 
     try:
         extra_args = ['--katex']
@@ -24,8 +24,6 @@ def render_markdown(value):
 
 
 def make_pdf(note):
-    import pypandoc
-
     extra_args = ['-V', 'geometry:margin=1in', '--pdf-engine', 'pdflatex',
                   '-V', 'colorlinks', '-V', 'urlcolor=NavyBlue']
 

--- a/anno/anno/static/anno.css
+++ b/anno/anno/static/anno.css
@@ -1,3 +1,10 @@
+/*
+ Off white : #F7E6DC
+ Dark blue : #0C016E
+ Light blue: #1AA2DB
+ Red       : #FA200A
+ Orange    : #FA6B34
+ */
 body {
     margin: 0;
     padding: 0;
@@ -161,12 +168,6 @@ a.label:hover {
     opacity: 0.8;
 }
 
-#edit-page #flashes {
-    color: #B95E04;
-    font-weight: bold;
-    height: 10px;
-}
-
 #edit-page #edit-field,
 #edit-page #edit-preview {
     width: 49%;
@@ -208,16 +209,17 @@ a.label:hover {
     margin-top: 20px;
 }
 
-.flashes {
-    padding: 10px;
-    list-style: none;
-    background-color: #B95E04;
-    color: white;
+#flashes-banner {
+    background-color: #FA200A;
+    height: 30px;
+    padding: 7px 0 5px 0;
 }
 
-.flashes p {
-    margin: 0 auto;
-    width: 706px;
+#flashes-banner p.flash {
+    color: white;
+    display: inline-block;
+    margin: 0;
+    vertical-align: middle;
 }
 
 figure {

--- a/anno/anno/templates/flashes.html
+++ b/anno/anno/templates/flashes.html
@@ -1,9 +1,11 @@
 {% with messages = get_flashed_messages() %}
-    <div id='flashes' class='content-wrapper'>
     {% if messages %}
+    <div id='flashes-banner' class='content-wrapper'>
+        <div class='content'>
         {% for message in messages %}
-            <p>{{ message }}</p>
+            <p class='flash'>{{ message }}</p>
         {% endfor %}
-    {% endif %}
+        </div>
     </div>
+    {% endif %}
 {% endwith %}

--- a/anno/anno/templates/note.html
+++ b/anno/anno/templates/note.html
@@ -16,6 +16,7 @@
     <link rel='stylesheet' href='{{ url_for("static", filename="anno.css") }}'/>
 </head>
 <body id='note-page'>
+    {% include 'flashes.html' %}
     <div class='nav-wrapper'>
         <div class='nav content'>
             <a class='btn' href='/'>Home</a>

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup_args = dict(
     url='https://github.com/gwgundersen/anno',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['flask>=1.1.1', 'pypandoc>=1.4'],
+    install_requires=['flask>=1.1.1', 'pypandoc>=1.4', 'markdown2'],
     entry_points={'console_scripts': ['anno = anno.annoapp:main']},
     python_requires='>=3.6'
 )


### PR DESCRIPTION
Pandoc is required to convert from Markdown to Latex (for PDFs), but it shouldn't be required for converting Markdown to HTML. We can just use [markdown2](https://github.com/trentm/python-markdown2) for that. This is nice because a user does not need to separately install Pandoc to get started.